### PR TITLE
Allow analyzer to be customized by project settings

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-for /d %%F in ("%ProgramFiles(x86)%\Microsoft Visual Studio\2017\*") DO (
+for /d %%F in ("%ProgramFiles(x86)%\Microsoft Visual Studio\2017\*") do (
  set MSBuild="%%F\MSBuild\15.0\Bin\MSBuild.exe"
  goto validate
 )

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
@@ -101,5 +101,11 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
         {
             return diangostics.OrderBy(d => d.Location.SourceSpan.Start);
         }
+
+        public AnalyzedProject AddAdditionalDocument(string filenName, string text)
+        {
+            var document = Project.AddAdditionalDocument(filenName, text);
+            return new AnalyzedProject(Analyzer, document.Project);
+        }
     }
 }

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
@@ -86,7 +86,7 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
             var analyzers = ImmutableArray.Create(analyzer);
             var documents = project.Documents;
             var compilation = project.GetCompilationAsync().Result;
-            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
+            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions);
             var diagnostics = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
 
             var documentDiagnostics = diagnostics.Where(d => d.Location.IsInSource)

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedProject.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Terrajobst.Pns.Analyzer.Test.Helpers
 {
-    public sealed class AnalyzedSolution
+    public sealed class AnalyzedProject
     {
         private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
@@ -20,21 +20,20 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
         private static readonly string VisualBasicDefaultExt = "vb";
         private static readonly string TestProjectName = "TestProject";
 
-        private AnalyzedSolution(Solution solution, ImmutableArray<AnalyzedDocument> documents)
+        private AnalyzedProject(Project project, ImmutableArray<AnalyzedDocument> documents)
         {
-            Solution = solution;
+            Project = project;
             Documents = documents;
         }
 
-        public Solution Solution { get; }
+        public Project Project { get; }
 
         public ImmutableArray<AnalyzedDocument> Documents { get; }
 
-        public static AnalyzedSolution Create(DiagnosticAnalyzer analyzer, string language, params string[] sources)
+        public static AnalyzedProject Create(DiagnosticAnalyzer analyzer, string language, params string[] sources)
         {
-            var solution = CreateSolution(sources, language);
+            var project = CreateProject(sources, language);
 
-            var project = solution.Projects.Single();
             var documents = project.Documents;
 
             var analyzers = ImmutableArray.Create(analyzer);
@@ -48,15 +47,10 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
             var analyzedDocuments = documents.Select(d => new AnalyzedDocument(d, SortDiagnostics(documentDiagnostics[d]).ToImmutableArray()))
                                              .ToImmutableArray();
 
-            return new AnalyzedSolution(solution, analyzedDocuments);
+            return new AnalyzedProject(project, analyzedDocuments);
         }
 
-        private static IEnumerable<Diagnostic> SortDiagnostics(IEnumerable<Diagnostic> diangostics)
-        {
-            return diangostics.OrderBy(d => d.Location.SourceSpan.Start);
-        }
-
-        private static Solution CreateSolution(string[] sources, string language)
+        private static Project CreateProject(string[] sources, string language)
         {
             string fileExtension = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
 
@@ -80,7 +74,14 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
                 count++;
             }
 
-            return solution;
+            var project = solution.GetProject(projectId);
+
+            return project;
+        }
+
+        private static IEnumerable<Diagnostic> SortDiagnostics(IEnumerable<Diagnostic> diangostics)
+        {
+            return diangostics.OrderBy(d => d.Location.SourceSpan.Start);
         }
     }
 }

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedSolution.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/AnalyzedSolution.cs
@@ -30,12 +30,7 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
 
         public ImmutableArray<AnalyzedDocument> Documents { get; }
 
-        public static AnalyzedSolution Create(string source, string language, DiagnosticAnalyzer analyzer)
-        {
-            return Create(new[] { source }, language, analyzer);
-        }
-
-        public static AnalyzedSolution Create(string[] sources, string language, DiagnosticAnalyzer analyzer)
+        public static AnalyzedSolution Create(DiagnosticAnalyzer analyzer, string language, params string[] sources)
         {
             var solution = CreateSolution(sources, language);
 

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
@@ -31,7 +31,7 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
                 throw new ArgumentException($"{nameof(expectedDiagnosticsText)} must match the number of marked spans.", nameof(expectedDiagnosticsText));
 
             var analyzer = CreateAnalyzer();
-            var actualDiagnostics = ComputeDiagnostics(source, analyzer);
+            var actualDiagnostics = ComputeDiagnostics(analyzer, source);
 
             Assert.Equal(expectedDiagnostics.Length, actualDiagnostics.Length);
 
@@ -69,11 +69,11 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
             }
         }
 
-        private ImmutableArray<Diagnostic> ComputeDiagnostics(string source, DiagnosticAnalyzer analyzer)
+        private ImmutableArray<Diagnostic> ComputeDiagnostics(DiagnosticAnalyzer analyzer, string source)
         {
             var language = GetLanguage();
-            var solution = AnalyzedSolution.Create(analyzer, language, source);
-            var document = solution.Documents.Single();
+            var project = AnalyzedProject.Create(analyzer, language, source);
+            var document = project.Documents.Single();
             return document.Diagnostics;
         }
     }

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
@@ -13,14 +13,16 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
     {
         protected abstract DiagnosticAnalyzer CreateAnalyzer();
 
+        protected virtual (string name, string defaultSettings) GetAdditionalFileSettings() => (null, null);
+
         protected abstract string GetLanguage();
 
-        protected void AssertNoMatch(string annotatedSource)
+        protected void AssertNoMatch(string annotatedSource, string settings = null)
         {
-            AssertMatch(annotatedSource, "");
+            AssertMatch(annotatedSource, "", settings);
         }
 
-        protected void AssertMatch(string annotatedSource, string expectedDiagnosticsText)
+        protected void AssertMatch(string annotatedSource, string expectedDiagnosticsText, string settings = null)
         {
             var annotatedText = AnnotatedText.Parse(annotatedSource);
             var source = annotatedText.Text;
@@ -31,7 +33,7 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
                 throw new ArgumentException($"{nameof(expectedDiagnosticsText)} must match the number of marked spans.", nameof(expectedDiagnosticsText));
 
             var analyzer = CreateAnalyzer();
-            var actualDiagnostics = ComputeDiagnostics(analyzer, source);
+            var actualDiagnostics = ComputeDiagnostics(analyzer, source, settings);
 
             Assert.Equal(expectedDiagnostics.Length, actualDiagnostics.Length);
 
@@ -69,10 +71,18 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
             }
         }
 
-        private ImmutableArray<Diagnostic> ComputeDiagnostics(DiagnosticAnalyzer analyzer, string source)
+        private ImmutableArray<Diagnostic> ComputeDiagnostics(DiagnosticAnalyzer analyzer, string source, string settings)
         {
             var language = GetLanguage();
             var project = AnalyzedProject.Create(analyzer, language, source);
+
+            var (settingsName, defaultSettings) = GetAdditionalFileSettings();
+            if (settingsName != null)
+            {
+                var effectiveSettings = defaultSettings + Environment.NewLine + settings;
+                project = project.AddAdditionalDocument(settingsName, effectiveSettings);
+            }
+
             var document = project.Documents.Single();
             return document.Diagnostics;
         }

--- a/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
+++ b/src/Terrajobst.Pns.Analyzer.Test/Helpers/DiagnosticTest.cs
@@ -72,7 +72,7 @@ namespace Terrajobst.Pns.Analyzer.Test.Helpers
         private ImmutableArray<Diagnostic> ComputeDiagnostics(string source, DiagnosticAnalyzer analyzer)
         {
             var language = GetLanguage();
-            var solution = AnalyzedSolution.Create(source, language, analyzer);
+            var solution = AnalyzedSolution.Create(analyzer, language, source);
             var document = solution.Documents.Single();
             return document.Diagnostics;
         }

--- a/src/Terrajobst.Pns.Analyzer.Test/Terrajobst.Pns.Analyzer.Test.csproj
+++ b/src/Terrajobst.Pns.Analyzer.Test/Terrajobst.Pns.Analyzer.Test.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" ExcludeAssets="All" />
     <PackageReference Include="System.Composition" Version="1.0.31" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Terrajobst.Pns.Analyzer/AnalyzerOptionsExtensions.cs
+++ b/src/Terrajobst.Pns.Analyzer/AnalyzerOptionsExtensions.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Terrajobst.Pns.Analyzer
+{
+    public static class AnalyzerOptionsExtensions
+    {
+        public static ImmutableDictionary<string, string> GetFileSettings(this AnalyzerOptions options, string fileName)
+        {
+            var additionalFile = options.AdditionalFiles.SingleOrDefault(a => string.Equals(Path.GetFileName(a.Path), fileName, StringComparison.OrdinalIgnoreCase));
+            if (additionalFile == null)
+                return ImmutableDictionary<string, string>.Empty;
+
+            var lines = additionalFile.GetText().Lines;
+            var result = new Dictionary<string, string>();
+
+            var previousKey = (string)null;
+
+            foreach (var line in lines)
+            {
+                var lineText = line.ToString().Trim();
+                if (lineText.Length == 0)
+                    continue;
+
+                var kv = ParseKeyValue(lineText);
+
+                // Don't throw if the key already exists. It's following the MBuild/CLI conventions where
+                // later values simply overwrite earlier options.
+                //
+                // Also, if the value is NULL, it means we need to associate it with the previous key.
+                // That's because the task writing the lines will put a new line for every semi-colon.
+                //
+                // For example, this configuration:
+                //
+                //      <PropertyGroup>
+                //          <Prop1>Value1;Value2</Prop1>
+                //          <Prop2>Value3</Prop2>
+                //      </PropertyGroup>
+                //
+                //      <ItemGroup>
+                //          <AdditionalFileContents Include="Prop1=$(Prop1);Prop2=$(Prop2)">
+                //              <AdditionalFileName>Foo.settings</AdditionalFile>
+                //          </AdditionalFileContents>
+                //      </ItemGroup>
+                //
+                // will create the file Foo.settings like this:
+                //
+                //      Prop1=Value1
+                //      Value2
+                //      Prop2=Value3
+
+                if (kv.Key != null)
+                {
+                    result[kv.Key] = kv.Value;
+                    previousKey = kv.Key;
+                }
+                else if (previousKey != null)
+                {
+                    if (result.ContainsKey(previousKey))
+                        result[previousKey] += ";" + kv.Value;
+                    else
+                        result[previousKey] = kv.Value;
+                }
+            }
+
+            return result.ToImmutableDictionary();
+        }
+
+        private static KeyValuePair<string, string> ParseKeyValue(string line)
+        {
+            var equalIndex = line.IndexOf('=');
+            if (equalIndex < 0)
+            {
+                var key = (string)null;
+                var value = line.Trim();
+                return new KeyValuePair<string, string>(key, value);
+            }
+            else
+            {
+                var key = line.Substring(0, equalIndex).Trim();
+                var value = line.Substring(equalIndex + 1).Trim(); ;
+                return new KeyValuePair<string, string>(key, value);
+            }
+        }
+    }
+}

--- a/src/Terrajobst.Pns.Analyzer/PnsOptions.cs
+++ b/src/Terrajobst.Pns.Analyzer/PnsOptions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Immutable;
+using Terrajobst.Pns.Analyzer.Store;
+
+namespace Terrajobst.Pns.Analyzer
+{
+    internal sealed class PnsOptions
+    {
+        public PnsOptions(ImmutableDictionary<string, string> options)
+        {
+            IgnoredPlatforms = ParseIgnoredPlatforms(options);
+            TargetFramework = ParseTargetFramework(options);
+        }
+
+        public Platform IgnoredPlatforms { get; }
+        public string TargetFramework { get; }
+
+        public static Platform ParseIgnoredPlatforms(ImmutableDictionary<string, string> options)
+        {
+            var result = Platform.None;
+
+            if (options.TryGetValue("PnsIgnore", out var value))
+            {
+                var names = value.Split(';');
+                foreach (var name in names)
+                {
+                    var trimmedNamed = name.Trim();
+                    if (Enum.TryParse<Platform>(trimmedNamed, out var platform))
+                        result |= platform;
+                }
+            }
+
+            return result;
+        }
+
+        public static string ParseTargetFramework(ImmutableDictionary<string, string> options)
+        {
+            options.TryGetValue("TargetFramework", out var value);
+            return value ?? string.Empty;
+        }
+    }
+}

--- a/src/Terrajobst.Pns.Analyzer/Terrajobst.Pns.Analyzer.csproj
+++ b/src/Terrajobst.Pns.Analyzer/Terrajobst.Pns.Analyzer.csproj
@@ -6,6 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="build\Terrajobst.Pns.Analyzer.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\Terrajobst.Pns.Analyzer.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
     <PackageReference Include="NuGet.CommandLine" Version="2.8.5" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
@@ -21,9 +31,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/src/Terrajobst.Pns.Analyzer/Terrajobst.Pns.Analyzer.nuspec
+++ b/src/Terrajobst.Pns.Analyzer/Terrajobst.Pns.Analyzer.nuspec
@@ -17,7 +17,8 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file target="analyzers\dotnet\cs" src="Terrajobst.Csv.dll"  />
-    <file target="analyzers\dotnet\cs" src="Terrajobst.Pns.Analyzer.dll"  />
+    <file target="analyzers\dotnet\cs" src="Terrajobst.Csv.dll" />
+    <file target="analyzers\dotnet\cs" src="Terrajobst.Pns.Analyzer.dll" />
+    <file target="build" src="build\Terrajobst.Pns.Analyzer.targets" />
   </files>
 </package>

--- a/src/Terrajobst.Pns.Analyzer/build/Terrajobst.Pns.Analyzer.targets
+++ b/src/Terrajobst.Pns.Analyzer/build/Terrajobst.Pns.Analyzer.targets
@@ -1,0 +1,31 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <AdditionalFileContent Include="PnsIgnore=$(PnsIgnore);TargetFramework=$(TargetFramework)">
+      <AdditionalFileName>Terrajobst.Pns.Analyzer.settings</AdditionalFileName>
+    </AdditionalFileContent>
+  </ItemGroup>
+
+  <!-- This target ensures our additional file is generated and passed to the compiler. -->
+
+  <Target Name="GenerateAdditionalFiles"
+          Inputs="@(AdditionalFileContent)"
+          Outputs="%(AdditionalFileName)"
+          BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_AdditionalFilePath>$(IntermediateOutputPath)%(AdditionalFileContent.AdditionalFileName)</_AdditionalFilePath>
+    </PropertyGroup>
+    <ReadLinesFromFile File="$(_AdditionalFilePath)" >
+      <Output TaskParameter="Lines" ItemName="_ExistingLines"/>
+    </ReadLinesFromFile>
+    <WriteLinesToFile Condition="'@(_ExistingLines)' != '@(AdditionalFileContent)'"
+                      Overwrite="True"
+                      File="$(_AdditionalFilePath)"
+                      Lines="@(AdditionalFileContent)" />
+    <ItemGroup>
+      <FileWrites Include="$(_AdditionalFilePath)" />
+      <AdditionalFiles Include="$(_AdditionalFilePath)" />
+    </ItemGroup>
+  </Target>
+
+</Project>


### PR DESCRIPTION
This allows the customer to tweak the analyzer behavior with project settings. For instance, the project can decide to ignore all issues for Linux and macOS by adding these settings to the project file:

```XML
<PropertyGroup>
  <PnsIngore>Linux;MacOSX</PnsIngore>
</PropertyGroup>
```
This change will also turn off the analyzer unless the project is targeting .NET Standard or .NET Core.